### PR TITLE
Support session_token for auth to get-password-data

### DIFF
--- a/lib/vagrant-aws-winrm/capability.rb
+++ b/lib/vagrant-aws-winrm/capability.rb
@@ -14,7 +14,8 @@ module VagrantPlugins
             # AWS connection info
             access_key_id     = machine.provider_config.access_key_id
             secret_access_key = machine.provider_config.secret_access_key 
-            credentials       = ::Aws::Credentials.new(access_key_id, secret_access_key)
+            session_token     = machine.provider_config.session_token
+            credentials       = ::Aws::Credentials.new(access_key_id, secret_access_key, session_token)
             region            = machine.provider_config.region
             region_config     = machine.provider_config.get_region_config(region)
             endpoint          = region_config.endpoint                        


### PR DESCRIPTION
Added 2 lines to include session_token from provider_config in AWS credentials used to authenticate the get-password-data api call.  This is needed if the account has MFA enabled or otherwise receives an aws session token via STS
